### PR TITLE
Fix dataloading for .xyz files

### DIFF
--- a/models/dataset.py
+++ b/models/dataset.py
@@ -21,7 +21,7 @@ def process_data(data_dir, dataname):
         pointcloud = trimesh.load(os.path.join(data_dir, dataname) + '.ply').vertices
         pointcloud = np.asarray(pointcloud)
     elif os.path.exists(os.path.join(data_dir, dataname) + '.xyz'):
-        pointcloud = np.load(os.path.join(data_dir, dataname)) + '.xyz'
+        pointcloud = np.load(os.path.join(data_dir, dataname) + '.xyz')
     else:
         print('Only support .xyz or .ply data. Please make adjust your data.')
         exit()


### PR DESCRIPTION
Hi, first off thanks for sharing this implementation, it's very convenient to get started with!

I encountered a bug that that prevents `.xyz` files from being loaded, this 1-line commit should fix it

To reproduce just add an `.xyz` file to the `data` folder (in my case `3DBenchy.xyz`) and run `python run.py --conf ./confs/npull.conf --dir benchy --dataname 3DBenchy_test`. The output I get is:

```
Data not found. Processing data...
Traceback (most recent call last):
  File "/home/linus/workspace/NeuralPull-Pytorch/run.py", line 190, in <module>
    runner = Runner(args, args.conf, args.mode)
  File "/home/linus/workspace/NeuralPull-Pytorch/run.py", line 38, in __init__
    self.dataset_np = DatasetNP(self.conf['dataset'], args.dataname)
  File "/home/linus/workspace/NeuralPull-Pytorch/models/dataset.py", line 85, in __init__
    process_data(self.data_dir, dataname)
  File "/home/linus/workspace/NeuralPull-Pytorch/models/dataset.py", line 24, in process_data
    pointcloud = np.load(os.path.join(data_dir, dataname)) + '.xyz'
  File "/home/linus/workspace/NeuralPull-Pytorch/venv-np/lib/python3.10/site-packages/numpy/lib/npyio.py", line 405, in load
    fid = stack.enter_context(open(os_fspath(file), "rb"))
FileNotFoundError: [Errno 2] No such file or directory: 'data/3DBenchy'
```